### PR TITLE
Use cpu=native and fix potential CICD errors

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = ["-C", "target-cpu=znver4"]
+rustflags = ["-C", "target-cpu=native"]
 
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 rustflags = ["-C", "target-cpu=znver4"]
+
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=znver4"]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build & Deploy
 on:
   push:
     branches:
-      - develop
+      - develop-experiment
 
 env:
   DEFAULT_TAGS: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build & Deploy
 on:
   push:
     branches:
-      - develop-experiment
+      - develop
 
 env:
   DEFAULT_TAGS: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,8 +67,8 @@ jobs:
           push: true
           tags: ${{ steps.worker-meta.outputs.tags }}
           labels: ${{ steps.worker-meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=min
 
       - name: Build and push leader
         uses: docker/build-push-action@v5
@@ -78,8 +78,8 @@ jobs:
           push: true
           tags: ${{ steps.leader-meta.outputs.tags }}
           labels: ${{ steps.leader-meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=min
 
   deploy:
     name: Deploy to GKE

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,3 @@ opt-level = 3
 incremental = true
 lto = "fat"
 codegen-units = 1
-
-# [build]
-# rustflags = ["-C", "target-cpu=native"]

--- a/coordinator.Dockerfile
+++ b/coordinator.Dockerfile
@@ -24,7 +24,7 @@ COPY coordinator/Cargo.toml ./coordinator/Cargo.toml
 
 COPY ./rust-toolchain.toml ./
 
-RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --bin coordinator 
+RUN cargo build --verbose --release --bin coordinator 
 
 COPY coordinator ./coordinator
 COPY ops ./ops

--- a/coordinator.Dockerfile
+++ b/coordinator.Dockerfile
@@ -4,12 +4,12 @@ FROM rustlang/rust:nightly-bullseye-slim@sha256:2be4bacfc86e0ec62dfa287949ceb47f
 RUN apt-get update && apt-get install -y libjemalloc2 libjemalloc-dev make libssl-dev pkg-config
 
 RUN \
-  mkdir -p ops/src     && touch ops/src/lib.rs && \
-  mkdir -p common/src  && touch common/src/lib.rs && \
-  mkdir -p rpc/src     && touch rpc/src/lib.rs && \
-  mkdir -p prover/src  && touch prover/src/lib.rs && \
-  mkdir -p leader/src && touch leader/src/lib.rs && \
-  mkdir -p coordinator/src  && echo "fn main() {println!(\"coordinator main\");}" > coordinator/src/main.rs
+    mkdir -p ops/src     && touch ops/src/lib.rs && \
+    mkdir -p common/src  && touch common/src/lib.rs && \
+    mkdir -p rpc/src     && touch rpc/src/lib.rs && \
+    mkdir -p prover/src  && touch prover/src/lib.rs && \
+    mkdir -p leader/src && touch leader/src/lib.rs && \
+    mkdir -p coordinator/src  && echo "fn main() {println!(\"coordinator main\");}" > coordinator/src/main.rs
 
 COPY Cargo.toml .
 RUN sed -i "2s/.*/members = [\"ops\", \"leader\", \"common\", \"rpc\", \"prover\", \"coordinator\"]/" Cargo.toml
@@ -24,7 +24,7 @@ COPY coordinator/Cargo.toml ./coordinator/Cargo.toml
 
 COPY ./rust-toolchain.toml ./
 
-RUN cargo build --verbose --release --bin coordinator 
+RUN cargo build --verbose --release --bin coordinator
 
 COPY coordinator ./coordinator
 COPY ops ./ops
@@ -34,14 +34,14 @@ COPY prover ./prover
 COPY leader ./leader
 
 RUN \
-  touch ops/src/lib.rs && \
-  touch common/src/lib.rs && \
-  touch rpc/src/lib.rs && \
-  touch prover/src/lib.rs && \
-  touch leader/src/main.rs && \
-  touch coordinator/src/main.rs
+    touch ops/src/lib.rs && \
+    touch common/src/lib.rs && \
+    touch rpc/src/lib.rs && \
+    touch prover/src/lib.rs && \
+    touch leader/src/main.rs && \
+    touch coordinator/src/main.rs
 
-RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --bin coordinator 
+RUN cargo build --verbose --release --bin coordinator
 
 FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y ca-certificates libjemalloc2

--- a/coordinator.Dockerfile
+++ b/coordinator.Dockerfile
@@ -24,7 +24,7 @@ COPY coordinator/Cargo.toml ./coordinator/Cargo.toml
 
 COPY ./rust-toolchain.toml ./
 
-RUN cargo build --release --bin coordinator 
+RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --bin coordinator 
 
 COPY coordinator ./coordinator
 COPY ops ./ops
@@ -41,7 +41,7 @@ RUN \
   touch leader/src/main.rs && \
   touch coordinator/src/main.rs
 
-RUN cargo build --release --bin coordinator 
+RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --bin coordinator 
 
 FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y ca-certificates libjemalloc2

--- a/coordinator.Dockerfile
+++ b/coordinator.Dockerfile
@@ -1,7 +1,7 @@
 FROM rustlang/rust:nightly-bullseye-slim@sha256:2be4bacfc86e0ec62dfa287949ceb47f9b6d9055536769bdee87b7c1788077a9 as builder
 
 # Install jemalloc
-RUN apt-get update && apt-get install -y libjemalloc2 libjemalloc-dev make libssl-dev pkg-config
+RUN apt-get update && apt-get install -y libjemalloc2 libjemalloc-dev make libssl-dev pkg-config clang-16
 
 RUN \
     mkdir -p ops/src     && touch ops/src/lib.rs && \

--- a/leader.Dockerfile
+++ b/leader.Dockerfile
@@ -1,7 +1,7 @@
 FROM rustlang/rust:nightly-bullseye-slim@sha256:2be4bacfc86e0ec62dfa287949ceb47f9b6d9055536769bdee87b7c1788077a9 as builder
 
 # Install jemalloc
-RUN apt-get update && apt-get install -y libjemalloc2 libjemalloc-dev make
+RUN apt-get update && apt-get install -y libjemalloc2 libjemalloc-dev make clang-16
 
 RUN \
     mkdir -p ops/src     && touch ops/src/lib.rs && \

--- a/leader.Dockerfile
+++ b/leader.Dockerfile
@@ -22,7 +22,7 @@ COPY leader/Cargo.toml ./leader/Cargo.toml
 
 COPY ./rust-toolchain.toml ./
 
-RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --bin leader 
+RUN cargo build --verbose --release --bin leader 
 
 COPY ops ./ops
 COPY common ./common

--- a/leader.Dockerfile
+++ b/leader.Dockerfile
@@ -4,11 +4,11 @@ FROM rustlang/rust:nightly-bullseye-slim@sha256:2be4bacfc86e0ec62dfa287949ceb47f
 RUN apt-get update && apt-get install -y libjemalloc2 libjemalloc-dev make
 
 RUN \
-  mkdir -p ops/src     && touch ops/src/lib.rs && \
-  mkdir -p common/src  && touch common/src/lib.rs && \
-  mkdir -p rpc/src     && touch rpc/src/lib.rs && \
-  mkdir -p prover/src  && touch prover/src/lib.rs && \
-  mkdir -p leader/src  && echo "fn main() {println!(\"YO!\");}" > leader/src/main.rs
+    mkdir -p ops/src     && touch ops/src/lib.rs && \
+    mkdir -p common/src  && touch common/src/lib.rs && \
+    mkdir -p rpc/src     && touch rpc/src/lib.rs && \
+    mkdir -p prover/src  && touch prover/src/lib.rs && \
+    mkdir -p leader/src  && echo "fn main() {println!(\"YO!\");}" > leader/src/main.rs
 
 COPY Cargo.toml .
 RUN sed -i "2s/.*/members = [\"ops\", \"leader\", \"common\", \"rpc\", \"prover\"]/" Cargo.toml
@@ -22,7 +22,7 @@ COPY leader/Cargo.toml ./leader/Cargo.toml
 
 COPY ./rust-toolchain.toml ./
 
-RUN cargo build --verbose --release --bin leader 
+RUN cargo build --verbose --release --bin leader
 
 COPY ops ./ops
 COPY common ./common
@@ -30,13 +30,13 @@ COPY rpc ./rpc
 COPY prover ./prover
 COPY leader ./leader
 RUN \
-  touch ops/src/lib.rs && \
-  touch common/src/lib.rs && \
-  touch rpc/src/lib.rs && \
-  touch prover/src/lib.rs && \
-  touch leader/src/main.rs
+    touch ops/src/lib.rs && \
+    touch common/src/lib.rs && \
+    touch rpc/src/lib.rs && \
+    touch prover/src/lib.rs && \
+    touch leader/src/main.rs
 
-RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --bin leader 
+RUN cargo build --verbose --release --bin leader
 
 FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y ca-certificates libjemalloc2

--- a/leader.Dockerfile
+++ b/leader.Dockerfile
@@ -22,7 +22,7 @@ COPY leader/Cargo.toml ./leader/Cargo.toml
 
 COPY ./rust-toolchain.toml ./
 
-RUN cargo build --release --bin leader 
+RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --bin leader 
 
 COPY ops ./ops
 COPY common ./common
@@ -36,7 +36,7 @@ RUN \
   touch prover/src/lib.rs && \
   touch leader/src/main.rs
 
-RUN cargo build --release --bin leader 
+RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --bin leader 
 
 FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y ca-certificates libjemalloc2

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -18,7 +18,7 @@ COPY worker/Cargo.toml ./worker/Cargo.toml
 
 COPY ./rust-toolchain.toml ./
 
-RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --bin worker 
+RUN cargo build --verbose --release --bin worker 
 
 COPY common ./common
 COPY ops ./ops

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -1,7 +1,7 @@
 FROM rustlang/rust:nightly-bullseye-slim@sha256:2be4bacfc86e0ec62dfa287949ceb47f9b6d9055536769bdee87b7c1788077a9 as builder
 
 # Install jemalloc
-RUN apt-get update && apt-get install -y libjemalloc2 libjemalloc-dev make
+RUN apt-get update && apt-get install -y libjemalloc2 libjemalloc-dev make clang-16
 
 RUN \
     mkdir -p common/src  && touch common/src/lib.rs && \

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -4,9 +4,9 @@ FROM rustlang/rust:nightly-bullseye-slim@sha256:2be4bacfc86e0ec62dfa287949ceb47f
 RUN apt-get update && apt-get install -y libjemalloc2 libjemalloc-dev make
 
 RUN \
-  mkdir -p common/src  && touch common/src/lib.rs && \
-  mkdir -p ops/src     && touch ops/src/lib.rs && \
-  mkdir -p worker/src  && echo "fn main() {println!(\"YO!\");}" > worker/src/main.rs
+    mkdir -p common/src  && touch common/src/lib.rs && \
+    mkdir -p ops/src     && touch ops/src/lib.rs && \
+    mkdir -p worker/src  && echo "fn main() {println!(\"YO!\");}" > worker/src/main.rs
 
 COPY Cargo.toml .
 RUN sed -i "2s/.*/members = [\"common\", \"ops\", \"worker\"]/" Cargo.toml
@@ -18,17 +18,17 @@ COPY worker/Cargo.toml ./worker/Cargo.toml
 
 COPY ./rust-toolchain.toml ./
 
-RUN cargo build --verbose --release --bin worker 
+RUN cargo build --verbose --release --bin worker
 
 COPY common ./common
 COPY ops ./ops
 COPY worker ./worker
 RUN \
-  touch common/src/lib.rs && \
-  touch ops/src/lib.rs && \
-  touch worker/src/main.rs
+    touch common/src/lib.rs && \
+    touch ops/src/lib.rs && \
+    touch worker/src/main.rs
 
-RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --bin worker 
+RUN cargo build --verbose --release --bin worker
 
 FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y ca-certificates libjemalloc2

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -18,7 +18,7 @@ COPY worker/Cargo.toml ./worker/Cargo.toml
 
 COPY ./rust-toolchain.toml ./
 
-RUN cargo build --release --bin worker 
+RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --bin worker 
 
 COPY common ./common
 COPY ops ./ops
@@ -28,7 +28,7 @@ RUN \
   touch ops/src/lib.rs && \
   touch worker/src/main.rs
 
-RUN cargo build --release --bin worker 
+RUN RUSTFLAGS='-C target-cpu=native' cargo build --release --bin worker 
 
 FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y ca-certificates libjemalloc2


### PR DESCRIPTION
1. Stops caching across builds.
    - This is necessary so that we can use `cpu=native` and safely change GCP machines.
2. Adds `cpu=native` to `.cargo/config.toml` for microarchitectural optimizations in `worker`, `leader`, `coordinator`.
2. Installs `clang-16` as system dependency in `worker`, `leader`, and `coordinator` Dockerfiles.
3. Adds `linker = "clang"` to `.cargo/Config.toml` for x86-64 Linux builds 
    - This prevents linking errors with the gcc linker.
5. Enables verbose logging for the `cargo build` commands in Dockerfiles. 