### PR TITLE
use default github action runner to save credits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   build:
     name: Build docker images
-    runs-on: gha-runner-set
+    runs-on: ubuntu-latest
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -83,7 +83,7 @@ jobs:
 
   deploy:
     name: Deploy to GKE
-    runs-on: gha-runner-set
+    runs-on: ubuntu-latest
     needs: build
     permissions:
       contents: 'read'


### PR DESCRIPTION
we don't need the self hosted runner anymore.